### PR TITLE
Fixed deprecated libav functions, crash, and compile time errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12.2)
+cmake_minimum_required(VERSION 3.5)
 project(drc_sim_c)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/src/data/Constants.h
+++ b/src/data/Constants.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include "../util/OSUtil.h"
+#include <cstdint>
 
 // General
 static const std::string NAME = "DRC Sim Server";

--- a/src/net/wiiu/packet/VideoPacketWiiU.h
+++ b/src/net/wiiu/packet/VideoPacketWiiU.h
@@ -5,6 +5,7 @@
 #ifndef DRC_SIM_C_VIDEO_WII_U_H
 #define DRC_SIM_C_VIDEO_WII_U_H
 #include "../../Packet.h"
+#include <cstdint>
 
 typedef struct {
     unsigned magic : 4;

--- a/src/util/OSUtil.cpp
+++ b/src/util/OSUtil.cpp
@@ -13,4 +13,5 @@ bool OSUtil::exists(const char *path) {
     struct stat file_info;
     if (stat(path, &file_info) != -1)
         return S_ISDIR(file_info.st_mode) or S_ISREG(file_info.st_mode) or S_ISLNK(file_info.st_mode);
+    return false;
 }


### PR DESCRIPTION
Removed deprecated `avcodec_register_all()` and replaced deprecated `avcodec_decode_video2()`  with `avcodec_send_packet()` and `avcodec_receive_frame()` for compatibility with newer versions of libav.

Also fixed compile time errors in `Constants.h` and `VideoPacketWiiU.h` (missing include).
Also fixed crash in `OSUtil.cpp` in function `OSUtil::exists()` (missing return statement).